### PR TITLE
Feat/#45 밥일기 작성 뷰 네비게이션 추가

### DIFF
--- a/momogum/Home/View/HomeView.swift
+++ b/momogum/Home/View/HomeView.swift
@@ -66,7 +66,7 @@ struct HomeView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack {
                         VStack {
-                            NavigationLink(destination: StoryView(userID: "")) {
+                            NavigationLink(destination: StoryView(userID: "", tabIndex: $tabIndex)) {
                                 Circle()
                                     .foregroundColor(Color(red: 207 / 255, green: 207 / 255, blue: 207 / 255)) // #CFCFCF 색상
                                     .cornerRadius(10)
@@ -117,7 +117,7 @@ struct HomeView: View {
                     ScrollView(.vertical, showsIndicators: false) {
                         LazyVGrid(columns: columns, spacing: 16) { // columns는 이미 정의된 GridItem 배열
                             ForEach(0..<6) { index in
-                                NavigationLink(destination: GalleryPickerView()) {
+                                NavigationLink(destination: GalleryPickerView(tabIndex: $tabIndex)) {
                                     VStack(spacing: 0) {
                                         // 상단 이미지 부분
                                         Rectangle()

--- a/momogum/Home/View/StoryView.swift
+++ b/momogum/Home/View/StoryView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct StoryView: View {
     var userID: String
+    @Binding var tabIndex: Int
     @Environment(\.presentationMode) var presentationMode // 뒤로가기 기능
     
     var body: some View {
@@ -36,7 +37,7 @@ struct StoryView: View {
                     .frame(width: 95, height: 95)
             }
             
-            NavigationLink(destination: GalleryPickerView()) {
+            NavigationLink(destination: GalleryPickerView(tabIndex: $tabIndex)) {
                 Text("바로 밥일기 작성하기")
                     .font(.headline)
                     .foregroundColor(Color(red: 224/255, green: 90/255, blue: 85/255)) // E05A55 색상
@@ -68,5 +69,5 @@ struct StoryView: View {
 }
 
 #Preview {
-    StoryView(userID: "유저아이디")
+    StoryView(userID: "유저아이디", tabIndex: .constant(0))
 }

--- a/momogum/MainTabView.swift
+++ b/momogum/MainTabView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct MainTabView: View {
     @State var tabIndex = 0
+    @State private var uploadViewID = UUID()
     
     //     UITabView 색상 초기화
     init() {
@@ -24,7 +25,8 @@ struct MainTabView: View {
                     Text("홈")
                 }
                 .tag(0)
-            GalleryPickerView()
+            GalleryPickerView(tabIndex: $tabIndex)
+                .id(uploadViewID)
                 .tabItem{
                     Image(systemName: "plus")
                     Text("업로드")
@@ -45,7 +47,12 @@ struct MainTabView: View {
             
         }
         .tint(Color(UIColor(red: 224/255, green: 90/255, blue: 85/255, alpha: 1.0)))
-
+        
+        .onChange(of: tabIndex) { newTab in
+                    if newTab == 1 {
+                        uploadViewID = UUID()
+                    }
+                }
     }
 }
 

--- a/momogum/Upload/ImageEditor/ImageEditorVIew.swift
+++ b/momogum/Upload/ImageEditor/ImageEditorVIew.swift
@@ -9,11 +9,13 @@ import SwiftUI
 
 struct ImageEditorView: View {
     @StateObject private var viewModel: ImageEditorViewModel
+    @Binding var tabIndex: Int 
     @Environment(\.dismiss) var dismiss
     @State private var navigationPath = NavigationPath()
 
-    init(image: UIImage) {
+    init(image: UIImage, tabIndex: Binding<Int>) {
         _viewModel = StateObject(wrappedValue: ImageEditorViewModel(image: image))
+        _tabIndex = tabIndex
     }
 
     var body: some View {
@@ -54,9 +56,9 @@ struct ImageEditorView: View {
 
                     VStack {
                         HStack {
-                            // Custom Back Button
+                            // Custom Back Button (Chevron)
                             Button(action: {
-                                dismiss()
+                                dismiss()  
                             }) {
                                 Image(systemName: "chevron.left")
                                     .foregroundColor(.black)
@@ -67,6 +69,8 @@ struct ImageEditorView: View {
                             Spacer()
 
                             Button(action: {
+                                viewModel.resetToOriginalImage()
+                                tabIndex = 0
                                 dismiss()
                             }) {
                                 Image(systemName: "xmark")
@@ -83,7 +87,7 @@ struct ImageEditorView: View {
                         Button(action: {
                             if let editedImage = viewModel.finalizeImage(frameSize: frameSize) {
                                 viewModel.image = editedImage
-                                navigationPath.append(viewModel.image) 
+                                navigationPath.append(viewModel.image)
                             }
                         }) {
                             Text("다음")
@@ -103,6 +107,7 @@ struct ImageEditorView: View {
             }
             .navigationDestination(for: UIImage.self) { image in
                 NewPostView(
+                    tabIndex: $tabIndex,
                     editedImage: image,
                     onReset: { viewModel.resetToOriginalImage() }
                 )
@@ -121,7 +126,5 @@ struct ImageEditorView: View {
 }
 
 #Preview {
-    NavigationStack {
-        ImageEditorView(image: UIImage(systemName: "photo") ?? UIImage())
-    }
+    ImageEditorView(image: UIImage(systemName: "photo") ?? UIImage(), tabIndex: .constant(0))
 }

--- a/momogum/Upload/ImagePicker/GalleryPickerView.swift
+++ b/momogum/Upload/ImagePicker/GalleryPickerView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct GalleryPickerView: View {
     @StateObject private var viewModel = GalleryPickerViewModel()
     @Environment(\.presentationMode) var presentationMode
+    @Binding var tabIndex: Int
 
     var body: some View {
         NavigationView {
@@ -27,7 +28,7 @@ struct GalleryPickerView: View {
                             LazyVGrid(columns: gridItems, spacing: 8) {
                                 ForEach(viewModel.images, id: \UIImage.hash) { image in
                                     NavigationLink(
-                                        destination: ImageEditorView(image: image)
+                                        destination: ImageEditorView(image: image, tabIndex: $tabIndex)
                                             .navigationBarBackButtonHidden(true)
                                             .navigationBarHidden(true)
                                     ) {
@@ -51,7 +52,7 @@ struct GalleryPickerView: View {
                     VStack {
                         HStack {
                             Button(action: {
-                                presentationMode.wrappedValue.dismiss()
+                                tabIndex = 0
                             }) {
                                 Image(systemName: "chevron.left")
                                     .foregroundColor(.black)
@@ -94,10 +95,10 @@ struct GalleryPickerView: View {
         }
         .toolbar(.hidden, for: .tabBar)
         .navigationBarBackButtonHidden(true)
-        .navigationBarHidden(true) 
+        .navigationBarHidden(true)
     }
 }
 
 #Preview {
-    GalleryPickerView()
+    GalleryPickerView(tabIndex: .constant(0))
 }

--- a/momogum/Upload/NewPost/NewPostView.swift
+++ b/momogum/Upload/NewPost/NewPostView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct NewPostView: View {
+    @Binding var tabIndex: Int
     @Environment(\.dismiss) var dismiss
     @StateObject private var viewModel = NewPostViewModel()
 
@@ -41,7 +42,7 @@ struct NewPostView: View {
                             Spacer()
 
                             Button(action: {
-                                dismiss()
+                                tabIndex = 0
                             }) {
                                 Image(systemName: "xmark")
                                     .foregroundColor(.black)
@@ -161,6 +162,7 @@ struct NewPostView: View {
 #Preview {
     NavigationView {
         NewPostView(
+            tabIndex: .constant(0),
             editedImage: UIImage(systemName: "photo") ?? UIImage(),
             onReset: {}
         )


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #45

## 📝작업 내용

> 각 뷰 chevron 버튼 네비게이션 구현
> 각 뷰 xmark 버튼 게비게이션 구현
> 메인 텝뷰, 홈뷰, 스토리뷰 tabIndex 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 이미지 편집 이후 밥일기 작성에서 xmark를 누르고 HomeView로 넘어갔다가 업로드를 누르면 이미지 편집창으로 바로 넘어가버려서 업로드 화면 초기화를 위해 MainTabView에 uploadView쪽 UUID 설정했습니다. 도리님께는 연락 드려놓은 상태이고, 다른 분들도 연관되어있는 파일이라고 생각되어 한 번씩 확인 해주시면 감사하겠습니다!
