### PR TITLE
Feat/#79

### DIFF
--- a/momogum/ContentView.swift
+++ b/momogum/ContentView.swift
@@ -9,15 +9,15 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var showMainView = false
-    @State private var isLoggedIn = false  // 로그인 상태 관리
+    @ObservedObject var authManager = AuthManager.shared
     @State var signupDataModel = SignupDataModel()
     var body: some View {
         ZStack{
             if showMainView{
-                if isLoggedIn{
+                if authManager.isLoggedIn{
                     MainTabView()
                 } else{
-                    LoginView(isLoggedIn: $isLoggedIn)
+                    LoginView()
                         .environment(signupDataModel)
                 }
                 

--- a/momogum/KeyChain.swift
+++ b/momogum/KeyChain.swift
@@ -1,0 +1,51 @@
+import Security
+import Foundation
+
+final class KeychainHelper {
+    static let shared = KeychainHelper()
+    
+    private init() {}
+    
+    /// **Keychain에 값 저장**
+    func save(_ value: String, forKey key: String) {
+        let data = Data(value.utf8)
+        let query = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: data
+        ] as CFDictionary
+
+        SecItemDelete(query) // 기존 값 삭제
+        let status = SecItemAdd(query, nil)
+        if status != errSecSuccess {
+            print(" Keychain 저장 실패")
+        }
+    }
+    
+    /// **Keychain에서 값 불러오기**
+    func get(forKey key: String) -> String? {
+        let query = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ] as CFDictionary
+        
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query, &dataTypeRef)
+        
+        if status == errSecSuccess, let data = dataTypeRef as? Data {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
+
+    /// **Keychain에서 값 삭제**
+    func delete(forKey key: String) {
+        let query = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key
+        ] as CFDictionary
+        SecItemDelete(query)
+    }
+}

--- a/momogum/Login/AuthService.swift
+++ b/momogum/Login/AuthService.swift
@@ -38,8 +38,8 @@ final class AuthService {
                     switch response.result {
                     case .success(let data):
                         print(" 회원가입 성공")
-                        print("🔹 isSuccess: \(data.isSuccess)")
-                        print("🔹 message: \(data.message)")
+                        print(" isSuccess: \(data.isSuccess)")
+                        print(" message: \(data.message)")
                         completion(.success(data))
                         
                     case .failure(let error):
@@ -53,6 +53,28 @@ final class AuthService {
                     }
                 }
         }
+    
+    
+    func checkDuplicateUsername(username: String, completion: @escaping (Result<Bool, APIError>) -> Void) {
+           let url = "\(BaseAPI)/auth/check-nickname?nickname=\(username)"
+           let headers: HTTPHeaders = ["Content-Type": "application/json"]
+
+           AF.request(url, method: .get, headers: headers)
+               .validate()
+               .responseDecodable(of: IsDuplicatedResponseModel.self) { response in
+                   switch response.result {
+                   case .success(let data):
+                       print(" 아이디 중복 확인 성공")
+                       print("isSuccess: \(data.isSuccess), 중복 여부: \(data.result)")
+                       completion(.success(data.result)) // `true`이면 중복, `false`이면 사용 가능
+
+                   case .failure(let error):
+                       print(" 아이디 중복 확인 실패")
+                       print("error: \(error.localizedDescription)")
+                       completion(.failure(self.handleError(error: error, response: response)))
+                   }
+               }
+       }
     
     
     

--- a/momogum/Login/AuthService.swift
+++ b/momogum/Login/AuthService.swift
@@ -9,20 +9,26 @@ final class AuthService {
     
     ///  신규 유저 확인 (API 요청)
     func checkIsNewUser(kakaoLoginModel: KakaoLoginModel, completion: @escaping (Result<IsNewUserResponseModel, APIError>) -> Void) {
-        let url = "\(BaseAPI)/auth/login/kakao"
-        let headers: HTTPHeaders = ["Content-Type": "application/json"]
+          let url = "\(BaseAPI)/auth/login/kakao"
+          let headers: HTTPHeaders = ["Content-Type": "application/json"]
 
-        AF.request(url, method: .post, parameters: kakaoLoginModel, encoder: JSONParameterEncoder.default, headers: headers)
-            .validate()
-            .responseDecodable(of: IsNewUserResponseModel.self) { response in
-                switch response.result {
-                case .success(let data):
-                    completion(.success(data))
-                    
-                case .failure(let error):
-                    completion(.failure(self.handleError(error: error, response: response)))
-                }
-            }
+          AF.request(url, method: .post, parameters: kakaoLoginModel, encoder: JSONParameterEncoder.default, headers: headers)
+              .validate()
+              .responseDecodable(of: IsNewUserResponseModel.self) { response in
+                  switch response.result {
+                  case .success(let data):
+                      print(" 유저 확인 성공: \(data)")
+                      completion(.success(data))
+
+                  case .failure(let error):
+                      print(" 유저 확인 실패: \(error.localizedDescription)")
+                      if let data = response.data {
+                          let responseString = String(data: data, encoding: .utf8)
+                          print(" 서버 응답 바디: \(String(describing: responseString))")
+                      }
+                      completion(.failure(self.handleError(error: error, response: response)))
+                  }
+              }
     }
 
     

--- a/momogum/Login/Model/RouteModel.swift
+++ b/momogum/Login/Model/RouteModel.swift
@@ -10,5 +10,5 @@ enum Route: Hashable{
     case  SignupStartView
     case  SignupStep1View
     case  SignupStep2View
-    case  MainTabView
+    case  SignupEndView
 }

--- a/momogum/Login/Model/SignupDataModel.swift
+++ b/momogum/Login/Model/SignupDataModel.swift
@@ -15,6 +15,7 @@ class SignupDataModel{
     var nickname = ""
     
     func creatUser(){
+        print("accessToken",accessToken)
         print("name",name)
         print("nickname",nickname)
     }

--- a/momogum/Login/Model/SignupDataModel.swift
+++ b/momogum/Login/Model/SignupDataModel.swift
@@ -10,6 +10,7 @@ import Foundation
 // 사용자로부터 받는 데이터
 @Observable
 class SignupDataModel{
+
     var accessToken: String = ""
     var name = ""
     var nickname = ""

--- a/momogum/Login/Model/isNewUserModel.swift
+++ b/momogum/Login/Model/isNewUserModel.swift
@@ -12,19 +12,51 @@ struct KakaoLoginModel: Codable {
     let provider, accessToken: String
 }
 
-// MARK: - IsNewUserResponseModel
 struct IsNewUserResponseModel: Codable {
     let isSuccess: Bool
     let code, message: String
-    let result: IsNewUserResult
+    let result: UserResultType
 }
 
-// MARK: - UserResult
-struct IsNewUserResult: Codable {
-    let id: Int?  //  id가 null일 수 있으므로 Optional 처리
+//  `enum`을 사용하여 result 타입을 구분
+enum UserResultType: Codable {
+    case user(UserResult) // 기존 유저 정보
+    case token(TokenResult) // 신규 유저 토큰 정보
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let userResult = try? container.decode(UserResult.self) {
+            self = .user(userResult)
+        } else if let tokenResult = try? container.decode(TokenResult.self) {
+            self = .token(tokenResult)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "UserResultType decoding failed")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .user(let userResult):
+            try container.encode(userResult)
+        case .token(let tokenResult):
+            try container.encode(tokenResult)
+        }
+    }
+}
+
+//  신규 유저 정보 구조체
+struct UserResult: Codable {
+    let id: Int?
     let name: String
-    let nickname: String?  //  null이 가능하므로 Optional 처리
-    let about: String?  //  null이 가능하므로 Optional 처리
+    let nickname: String?
+    let about: String?
     let profileImage: String
     let newUser: Bool
+}
+
+//  기존 유저 (토큰 반환)
+struct TokenResult: Codable {
+    let accessToken: String
+    let refreshToken: String
 }

--- a/momogum/Login/View/LoginView.swift
+++ b/momogum/Login/View/LoginView.swift
@@ -38,17 +38,16 @@ struct LoginView: View {
                             print("카카오 로그인 성공!")
                             
                             authViewModel.checkIsNewUser { isSuccess, isNew in
-                                if isSuccess {
-                                    if isNew {
+                                if isSuccess { //로그인 성공 true
+                                    if isNew { //신규인경우 true
                                         path.append(.SignupStartView)
                                         print("신규 유저입니다. 회원가입이 필요합니다.")
-                                    } else {
+                                    } else { // true false  기존유저
                                         AuthManager.shared.isLoggedIn = true
                                         print("기존 유저 로그인 완료")
                                     }
                                 } else {
 //                                    path.append(.SignupStartView)
-                                    AuthManager.shared.isLoggedIn = true
                                     print("❌ 유저 확인 실패")
                                 }
                             }  } else {

--- a/momogum/Login/View/LoginView.swift
+++ b/momogum/Login/View/LoginView.swift
@@ -47,6 +47,7 @@ struct LoginView: View {
                                         print("기존 유저 로그인 완료")
                                     }
                                 } else {
+//                                    path.append(.SignupStartView)
                                     AuthManager.shared.isLoggedIn = true
                                     print("❌ 유저 확인 실패")
                                 }
@@ -69,9 +70,8 @@ struct LoginView: View {
                         
                     case.SignupStep2View:
                         SignupStep2View(path: $path)
-                        
-                    case.MainTabView:
-                        MainTabView()
+                    case.SignupEndView:
+                        SignupEndView(path: $path)
                     }
                     
                 }

--- a/momogum/Login/View/LoginView.swift
+++ b/momogum/Login/View/LoginView.swift
@@ -12,7 +12,6 @@ struct LoginView: View {
     @FocusState private var isFocused: Bool // TextField의 포커스 상태
     @FocusState private var isFocusedPWD: Bool
     @State private var path: [Route] = [] //path 설정
-    @Binding var isLoggedIn: Bool
     var body: some View {
         
         NavigationStack(path: $path){
@@ -44,13 +43,11 @@ struct LoginView: View {
                                         path.append(.SignupStartView)
                                         print("신규 유저입니다. 회원가입이 필요합니다.")
                                     } else {
-                                        isLoggedIn = true
+                                        AuthManager.shared.isLoggedIn = true
                                         print("기존 유저 로그인 완료")
                                     }
                                 } else {
-                                    path.append(.SignupStartView)
-
-//                                    isLoggedIn = true // 백엔드쪽오류로 일단은 열어놓기
+                                    AuthManager.shared.isLoggedIn = true
                                     print("❌ 유저 확인 실패")
                                 }
                             }  } else {
@@ -99,5 +96,5 @@ struct LoginView: View {
 
 
 #Preview {
-    LoginView(isLoggedIn: .constant(false))
+    LoginView()
 }

--- a/momogum/Login/View/LoginView.swift
+++ b/momogum/Login/View/LoginView.swift
@@ -48,7 +48,9 @@ struct LoginView: View {
                                         print("기존 유저 로그인 완료")
                                     }
                                 } else {
-                                    isLoggedIn = true // 백엔드쪽오류로 일단은 열어놓기
+                                    path.append(.SignupStartView)
+
+//                                    isLoggedIn = true // 백엔드쪽오류로 일단은 열어놓기
                                     print("❌ 유저 확인 실패")
                                 }
                             }  } else {

--- a/momogum/Login/View/SignupEndView.swift
+++ b/momogum/Login/View/SignupEndView.swift
@@ -1,0 +1,43 @@
+//
+//  SignupEndView.swift
+//  momogum
+//
+//  Created by 서재민 on 2/12/25.
+//
+
+import SwiftUI
+
+struct SignupEndView: View {
+    @Binding var path: [Route]
+
+    
+    var body: some View {
+        VStack{
+            Text("정보 입력 완료!")
+                .fontWeight(.semibold)
+                .foregroundStyle(.Red_2)
+                .font(.system(size: 28))
+                .padding(.top,152)
+            Text("맛있는 순간을 머머금과 함께해요!")
+                .font(.mmg(.subheader3))
+                .padding(.top,12)
+                .foregroundStyle(.signupStartTextblack)
+            Image("SignupStartLogo")
+                .resizable()
+                .frame(width: 229, height: 229)
+                .padding(.top,90)
+            Spacer()
+        }
+        .navigationBarBackButtonHidden()
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                path = []
+                AuthManager.shared.isLoggedIn = true
+            }
+        }
+    }
+}
+
+#Preview {
+    SignupEndView(path: .constant([]))
+}

--- a/momogum/Login/View/SignupStep1View.swift
+++ b/momogum/Login/View/SignupStep1View.swift
@@ -11,8 +11,8 @@ struct SignupStep1View: View {
    //MARK: - Properties
     
     @Environment(\.dismiss) var dismiss
-//    @Environment(SignupDataModel.self) var signupDataModel
-    @State private var inputText: String = ""
+    @Environment(SignupDataModel.self) var signupDataModel
+//    @State private var inputText: String = ""
 
     @FocusState private var isFocused: Bool // TextField의 포커스 상태
     
@@ -22,7 +22,7 @@ struct SignupStep1View: View {
     
     //MARK: - View
     var body: some View {
-//        @Bindable var signupDataModel = signupDataModel
+        @Bindable var signupDataModel = signupDataModel
         ZStack (alignment: .bottomTrailing) {
             VStack{
                 HStack{
@@ -77,7 +77,7 @@ struct SignupStep1View: View {
                     
                     VStack{
                         HStack{
-                            TextField("최대 12자 이내의 한글, 영문 사용 가능", text: $inputText /*$signupDataModel.name*/,onEditingChanged: { editing in
+                            TextField("최대 12자 이내의 한글, 영문 사용 가능", text: /*$inputText*/ $signupDataModel.name,onEditingChanged: { editing in
                                 if editing {
                                     isFocused = true
                                     
@@ -87,16 +87,18 @@ struct SignupStep1View: View {
                             .modifier(SignupTextfieldModifer())
                             .focused($isFocused)
                             .foregroundStyle(isFocused ? Color.black : Color.black_3)
-                            .onChange(of: inputText /*signupDataModel.name*/) { _, newValue in
+                            .onChange(of: /*inputText*/ signupDataModel.name) { _, newValue in
                                 // 입력 값 길이 제한
                                 if isFocused && newValue.count > 1 {
-                                    showError = !validateInput(/*signupDataModel.name*/inputText) || newValue.count > 12
+                                    showError = !validateInput(signupDataModel.name/*inputText*/) || newValue.count > 12
                                 }
                             }
                             
-                            if !inputText.isEmpty {
+                            if /*!inputText*/!signupDataModel.name.isEmpty {
                                 Button(action: {
-                                    inputText = "" // 입력 내용 초기화
+//                                    inputText = ""
+                                    signupDataModel.name = ""
+                                    // 입력 내용 초기화
                                 }) {
                                     Image(systemName: "xmark.circle")
                                         .foregroundColor(.gray)
@@ -116,14 +118,14 @@ struct SignupStep1View: View {
                         
 
                         
-                        if showError && isFocused && !validateInput(inputText/*signupDataModel.name*/) {
+                        if showError && isFocused && !validateInput(/*inputText*/signupDataModel.name) {
                             Text("잘못된 입력입니다.")
                                 .foregroundColor(.Red_1)
                                 .font(.mmg(.Caption1))
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.leading,43)
                         }
-                        else if !showError  && validateInput(inputText/*signupDataModel.name*/)  {
+                        else if !showError  && validateInput(/*inputText*/signupDataModel.name)  {
                             Text("사용 가능한 이름이에요 :)")
                                 .foregroundColor(.Green_1)
                                 .font(.mmg(.Caption1))
@@ -145,8 +147,8 @@ struct SignupStep1View: View {
                                         .padding(.trailing, 49)
                     .frame(maxWidth: .infinity, alignment: .trailing)
                     .padding(.bottom ,93)
-                    .disabled(showError || !validateInput(inputText/*signupDataModel.name*/))
-                    .foregroundStyle(showError  || !validateInput(inputText/*signupDataModel.name*/) ? .gray : .Red_2)
+                    .disabled(showError || !validateInput(/*inputText*/signupDataModel.name))
+                    .foregroundStyle(showError  || !validateInput(/*inputText*/signupDataModel.name) ? .gray : .Red_2)
                     
                 }
                 .navigationBarBackButtonHidden()

--- a/momogum/Login/View/SignupStep2View.swift
+++ b/momogum/Login/View/SignupStep2View.swift
@@ -169,7 +169,7 @@ struct SignupStep2View: View {
                         
                         if isButtonEnabled && authViewModel.isUsernameDuplicated==false{
                             Button{
-                                path = []
+                                path.append(.SignupEndView)
                                 print(signupDataModel.creatUser())
                                 
                             }label: {

--- a/momogum/Login/View/SignupStep2View.swift
+++ b/momogum/Login/View/SignupStep2View.swift
@@ -10,12 +10,12 @@ import SwiftUI
 struct SignupStep2View: View {
     //MARK: - Properties
     @Environment(\.dismiss) var dismiss
-//    @Environment(SignupDataModel.self) var signupDataModel
-    @State private var inputText: String = ""
+    @ObservedObject var authViewModel = AuthViewModel()
+    @Environment(SignupDataModel.self) var signupDataModel
+//    @State private var inputText: String = ""
     @FocusState private var isFocused: Bool
     @State private var lengthCheck: Bool = false
     @State private var hasAllowedCharactersOnly: Bool = false
-    @State private var isDuplicated: Bool = false
     private var isButtonEnabled: Bool {
            return lengthCheck && hasAllowedCharactersOnly
        }
@@ -23,7 +23,7 @@ struct SignupStep2View: View {
     //MARK: - View
     var body: some View {
         
-        //        @Bindable var signupDataModel = signupDataModel
+                @Bindable var signupDataModel = signupDataModel
         ZStack (alignment: .bottomTrailing) {
             VStack{
                 HStack{
@@ -75,7 +75,7 @@ struct SignupStep2View: View {
                         
                         HStack{
                             
-                            TextField("ex.momogum12._.", text: $inputText /*$signupDataModel.nickname*/ ,onEditingChanged: { editing in
+                            TextField("ex.momogum12._.", text: /*$inputText*/ $signupDataModel.nickname ,onEditingChanged: { editing in
                                 if editing {
                                     isFocused = true
                                 }
@@ -83,13 +83,14 @@ struct SignupStep2View: View {
                             .modifier(SignupTextfieldModifer())
                             .focused($isFocused)
                             .foregroundStyle(isFocused ? Color.black : Color.signupDescriptionGray)
-                            .onChange(of: inputText /*signupDataModel.nickname*/) { _ , newValue in
+                            .onChange(of: /*inputText*/ signupDataModel.nickname) { _ , newValue in
                                 validateInput2(newValue)
                             }
 
-                            if !inputText.isEmpty {
+                            if /*inputText*/!signupDataModel.nickname.isEmpty {
                                 Button(action: {
-                                    inputText = "" // 입력 내용 초기화
+                                    /*inputText = ""*/ // 입력 내용 초기화
+                                    signupDataModel.nickname = ""
                                 }) {
                                     Image(systemName: "xmark.circle")
                                         .foregroundColor(.gray)
@@ -125,7 +126,7 @@ struct SignupStep2View: View {
                         
                         
                         VStack{
-                            if isButtonEnabled && isDuplicated{
+                            if isButtonEnabled && authViewModel.isUsernameDuplicated==false{
                                 Text("사용 가능한 아이디입니다:)")
                                     .font(.system(size:16))
                                     .fontWeight(.regular)
@@ -166,11 +167,10 @@ struct SignupStep2View: View {
                         .padding(.leading, 43)
                         .foregroundStyle(Color.placeholderGray)
                         
-                        if isButtonEnabled && isDuplicated{
+                        if isButtonEnabled && authViewModel.isUsernameDuplicated==false{
                             Button{
                                 path = []
-                              
-                                print(path)
+                                print(signupDataModel.creatUser())
                                 
                             }label: {
                                 Text("완료")
@@ -180,18 +180,15 @@ struct SignupStep2View: View {
                                     .frame(maxWidth: .infinity, alignment: .trailing)
                                     .foregroundStyle(!isButtonEnabled ? Color.black_4: Color.momogumRed)
                                     .clipShape(RoundedRectangle(cornerRadius: 10))
+                                    
                             }
                             .padding(.trailing, 47)
                             .padding(.bottom, 93)
                         }
                         else{
                             Button{
-                                //                            print(signupDataModel.creatUser())
-                                if !isDuplicated{
-                                    print(isDuplicated)
-                                    isDuplicated = true
-                                    
-                                }
+                          
+                                authViewModel.checkUsernameisDuplicated()
                                 
                             }label:{
                                 Text("중복확인")
@@ -199,7 +196,7 @@ struct SignupStep2View: View {
                             .font(.mmg(.subheader3))
                             .foregroundStyle(isButtonEnabled ? Color.Red_2 : Color.black_4)
                             .disabled(!isButtonEnabled)
-                            .disabled(isDuplicated)
+                            .disabled(authViewModel.isUsernameDuplicated==false)
                             .padding(.trailing, 47)
                             .padding(.bottom, 93)
                         }

--- a/momogum/Login/View/SignupStep2View.swift
+++ b/momogum/Login/View/SignupStep2View.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SignupStep2View: View {
     //MARK: - Properties
     @Environment(\.dismiss) var dismiss
-    @ObservedObject var authViewModel = AuthViewModel()
+    @StateObject var authViewModel = AuthViewModel()
     @Environment(SignupDataModel.self) var signupDataModel
 //    @State private var inputText: String = ""
     @FocusState private var isFocused: Bool
@@ -169,6 +169,7 @@ struct SignupStep2View: View {
                         
                         if isButtonEnabled && authViewModel.isUsernameDuplicated==false{
                             Button{
+                                authViewModel.signup()
                                 path.append(.SignupEndView)
                                 print(signupDataModel.creatUser())
                                 

--- a/momogum/Login/ViewModel/AuthViewModel.swift
+++ b/momogum/Login/ViewModel/AuthViewModel.swift
@@ -7,9 +7,9 @@ final class AuthViewModel: ObservableObject {
     @Published var isNewUser: Bool?
     @Published var errorMessage: String?
     @Published var isSignedUp = false
+    @Published var isUsernameDuplicated: Bool? = nil // ✅ 중복 여부 저장
     @Published var kakaoAccessToken: String = ""
-
-    var signupData = SignupDataModel()
+    @Published var signupData = SignupDataModel()
 
     ///
     ///
@@ -46,7 +46,7 @@ final class AuthViewModel: ObservableObject {
     func signup() {
         
         let signupModel = signupData.createSignupModel()
-
+        let accessToken = kakaoAccessToken
             AuthService.shared.signup(signupModel: signupModel) { [weak self] result in
                 DispatchQueue.main.async {
                     switch result {
@@ -91,7 +91,28 @@ final class AuthViewModel: ObservableObject {
         }
     }
     
-    
+    func checkUsernameisDuplicated() {
+        AuthService.shared.checkDuplicateUsername(username: signupData.name) { [weak self] result in
+               DispatchQueue.main.async {
+                   switch result {
+                   case .success(let isDuplicated):
+                       if isDuplicated {
+                           print("중복확인: 사용자가 있습니다.")
+                           self?.isUsernameDuplicated = isDuplicated
+                           
+                       }
+                       else if !isDuplicated{
+                           print("중복확인: 사용 가능한 아이디입니다!")
+                           self?.isUsernameDuplicated = isDuplicated
+                       }
+                       
+                   case .failure:
+                       print("api 통신에러")
+                       self?.isUsernameDuplicated = nil
+                   }
+               }
+           }
+       }
     
     
     func handleKakaoLogout(){

--- a/momogum/Login/ViewModel/AuthViewModel.swift
+++ b/momogum/Login/ViewModel/AuthViewModel.swift
@@ -46,7 +46,7 @@ final class AuthViewModel: ObservableObject {
     func signup() {
         
         let signupModel = signupData.createSignupModel()
-        let accessToken = kakaoAccessToken
+//        let accessToken = kakaoAccessToken
             AuthService.shared.signup(signupModel: signupModel) { [weak self] result in
                 DispatchQueue.main.async {
                     switch result {

--- a/momogum/Manager/AuthManager.swift
+++ b/momogum/Manager/AuthManager.swift
@@ -13,7 +13,8 @@ final class AuthManager : ObservableObject {
     private init() {}
     
     private let defaults = UserDefaults.standard
-    
+    private let accessTokenKey = "kakaoAccessToken"
+
     var UUID: Int? {
         get {
             let value = defaults.integer(forKey: "UUID")
@@ -29,6 +30,20 @@ final class AuthManager : ObservableObject {
         }
     }
     
+    //토큰 저장 키체인
+    var kakaoAccessToken: String? {
+            get {
+                return KeychainHelper.shared.get(forKey: accessTokenKey)
+            }
+            set {
+                if let token = newValue {
+                    KeychainHelper.shared.save(token, forKey: accessTokenKey)
+                } else {
+                    KeychainHelper.shared.delete(forKey: accessTokenKey)
+                }
+            }
+        }
+    
     func updateLoginState(isLoggedIn: Bool) {
             DispatchQueue.main.async {
                 self.isLoggedIn = isLoggedIn
@@ -43,4 +58,16 @@ final class AuthManager : ObservableObject {
     func handleLoginSuccess() {
         UserDefaults.standard.setValue(true, forKey: "isLoggedIn")
     }
+    
+    
+    // 오토로그인 추후 구현예정    
+    func checkAutoLogin() {
+            if let token = kakaoAccessToken, !token.isEmpty {
+                isLoggedIn = true
+                print("✅ 자동 로그인 성공: \(token)")
+            } else {
+                isLoggedIn = false
+                print("❌ 저장된 토큰 없음, 로그인 필요")
+            }
+        }
 }

--- a/momogum/Manager/AuthManager.swift
+++ b/momogum/Manager/AuthManager.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-final class AuthManager {
+final class AuthManager : ObservableObject {
     static let shared = AuthManager()
-    
+    @Published var isLoggedIn: Bool = false
     private init() {}
     
     private let defaults = UserDefaults.standard
@@ -29,10 +29,18 @@ final class AuthManager {
         }
     }
     
-    
+    func updateLoginState(isLoggedIn: Bool) {
+            DispatchQueue.main.async {
+                self.isLoggedIn = isLoggedIn
+            }
+        }
     
     
     func clearUserData() {
           defaults.removeObject(forKey: "UUID")
       }
+    
+    func handleLoginSuccess() {
+        UserDefaults.standard.setValue(true, forKey: "isLoggedIn")
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
keychain추가, isNewModel 변경에따른 뷰모델 수정
로그인, 회원가입 정상적으로 작동합니다

UUID값을 받아오는 방식을 현재는 로그인할때 값을 뽑아오는 방식으로 설정했는데, 보안성이 떨어져서 추후에 머랭님이 따로 api 작업하셔서 현재로그인한 유저의 UUID값 받아오는 방식이 바뀔예정입니다. 혹시라도 UUID값을 넣어서 api 연동되는지 확인하고싶으신 분들은 1,2,3,4 test값으로 넣어두셨다고하니 지금 당장은 로그인한 UUID로는 정상적인 api연동이 안될 수도 있다는 점을 인지해주시길 바랍니다.
